### PR TITLE
Make linter happy with CamelCase const names

### DIFF
--- a/packstream/packstream.go
+++ b/packstream/packstream.go
@@ -14,41 +14,42 @@ type ByteStructures struct {
 	size     int
 }
 
+// Useful constant definitions
 const (
-	TINY_STRING_START = 0x80
-	TINY_STRING_END   = 0x8F
-	STRING_SIZE_8     = 0xD0
-	STRING_SIZE_16    = 0xD1
-	STRING_SIZE_32    = 0xD2
+	TinyStringStart = 0x80
+	TinyStringEnd   = 0x8F
+	StringSize8     = 0xD0
+	StringSize16    = 0xD1
+	StringSize32    = 0xD2
 
-	TINY_LIST_START = 0x90
-	TINY_LIST_END   = 0x9F
-	LIST_SIZE_8     = 0xD4
-	LIST_SIZE_16    = 0xD5
-	LIST_SIZE_32    = 0xD6
+	TinyListStart = 0x90
+	TinyListEnd   = 0x9F
+	ListSize8     = 0xD4
+	ListSize16    = 0xD5
+	ListSize32    = 0xD6
 
-	TINY_MAP_START = 0xA0
-	TINY_MAP_END   = 0xAF
-	MAP_SIZE_8     = 0xD8
-	MAP_SIZE_16    = 0xD9
-	MAP_SIZE_32    = 0xDA
+	TinyMapStart = 0xA0
+	TinyMapEnd   = 0xAF
+	MapSize8     = 0xD8
+	MapSize16    = 0xD9
+	MapSize32    = 0xDA
 
-	TINY_STRUCT_START = 0xB0
-	TINY_STRUCT_END   = 0xBF
-	STRUCT_SIZE_8     = 0xDC
-	STRUCT_SIZE_16    = 0xDD
+	TinyStructStart = 0xB0
+	TinyStructEnd   = 0xBF
+	StructSize8     = 0xDC
+	StructSize16    = 0xDD
 
-	NULL     = 0xC0
-	FLOAT_64 = 0xC1
-	FALSE    = 0xC2
-	TRUE     = 0xC3
+	Null    = 0xC0
+	Float64 = 0xC1
+	False   = 0xC2
+	True    = 0xC3
+	Int8    = 0xC8
+	Int16   = 0xC9
+	Int32   = 0xCA
+	Int64   = 0xCB
 
-	MIN_TINY_INT = -16
-	MAX_TINY_INT = 127
-	INT_8        = 0xC8
-	INT_16       = 0xC9
-	INT_32       = 0xCA
-	INT_64       = 0xCB
+	MinTinyInt = -16
+	MaxTinyInt = 127
 )
 
 type Decoder struct {
@@ -74,18 +75,18 @@ func (dec Decoder) Decode() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if int8(b) >= MIN_TINY_INT && int8(b) <= MAX_TINY_INT {
+	if int8(b) >= MinTinyInt && int8(b) <= MaxTinyInt {
 		return int(int8(b)), nil
 	}
 	switch b {
-	case FALSE:
+	case False:
 		return false, nil
-	case TRUE:
+	case True:
 		return true, nil
-	case INT_8:
+	case Int8:
 		i, err := dec.br.ReadByte()
 		return int(int8(i)), err
-	case INT_16:
+	case Int16:
 		barr := [2]byte{}
 		n, err := dec.br.Read(barr[:])
 		if err != nil {
@@ -98,7 +99,7 @@ func (dec Decoder) Decode() (interface{}, error) {
 		v |= int16(barr[0]) << 8
 		v |= int16(barr[1])
 		return int(int16(v)), nil
-	case INT_32:
+	case Int32:
 		barr := [4]byte{}
 		n, err := dec.br.Read(barr[:])
 		if err != nil {
@@ -113,7 +114,7 @@ func (dec Decoder) Decode() (interface{}, error) {
 		v |= int32(barr[2]) << 8
 		v |= int32(barr[3])
 		return int(int32(v)), nil
-	case INT_64:
+	case Int64:
 		barr := [8]byte{}
 		n, err := dec.br.Read(barr[:])
 		if err != nil {
@@ -154,9 +155,9 @@ func (enc Encoder) encodeBool(b bool) error {
 	var n int
 	var err error
 	if b {
-		n, err = enc.bw.Write([]byte{TRUE})
+		n, err = enc.bw.Write([]byte{True})
 	} else {
-		n, err = enc.bw.Write([]byte{FALSE})
+		n, err = enc.bw.Write([]byte{False})
 	}
 	if err != nil {
 		return err
@@ -172,7 +173,7 @@ func (enc Encoder) encodeBool(b bool) error {
 func (enc Encoder) encodeFloat64(f float64) error {
 	v := math.Float64bits(f)
 	b := [9]byte{}
-	b[0] = FLOAT_64
+	b[0] = Float64
 	b[1] = byte(v >> 56)
 	b[2] = byte(v >> 48)
 	b[3] = byte(v >> 40)
@@ -196,7 +197,7 @@ func (enc Encoder) encodeInt64(i int64) error {
 	switch {
 	case (i >= -9223372036854775808 && i <= -2147483649) || (i >= 2147483648 && i <= 9223372036854775807): // INT_64
 		b := [9]byte{}
-		b[0] = INT_64
+		b[0] = Int64
 		b[1] = byte(i >> 56)
 		b[2] = byte(i >> 48)
 		b[3] = byte(i >> 40)
@@ -220,14 +221,14 @@ func (enc Encoder) encodeInt64(i int64) error {
 		return enc.encodeInt16(int(i))
 	case i >= -128 && i <= -17: // INT_8
 		return enc.encodeInt8(int(i))
-	case i >= MIN_TINY_INT && i <= MAX_TINY_INT: // TINY_INT
+	case i >= MinTinyInt && i <= MaxTinyInt: // TINY_INT
 		return enc.encodeTinyInt(int(i))
 	}
 	return errors.New("invalid int64: this should not happen")
 }
 
 func (enc Encoder) encodeTinyInt(i int) error {
-	if i < MIN_TINY_INT || i > MAX_TINY_INT {
+	if i < MinTinyInt || i > MaxTinyInt {
 		return errors.New("encode tinyint: out of range")
 	}
 	b := byte(i)
@@ -246,7 +247,7 @@ func (enc Encoder) encodeInt8(i int) error {
 	if i < -128 || i > 127 {
 		return errors.New("encode int8: out of range")
 	}
-	n, err := enc.bw.Write([]byte{INT_8, byte(i)})
+	n, err := enc.bw.Write([]byte{Int8, byte(i)})
 	if err != nil {
 		return err
 	}
@@ -262,7 +263,7 @@ func (enc Encoder) encodeInt16(i int) error {
 		return errors.New("encode int16: out of range")
 	}
 	b := [3]byte{}
-	b[0] = INT_16
+	b[0] = Int16
 	b[1] = byte(i >> 8)
 	b[2] = byte(i)
 	n, err := enc.bw.Write(b[:])
@@ -281,7 +282,7 @@ func (enc Encoder) encodeInt32(i int) error {
 		return errors.New("encode int32: out of range")
 	}
 	b := [5]byte{}
-	b[0] = INT_32
+	b[0] = Int32
 	b[1] = byte(i >> 24)
 	b[2] = byte(i >> 16)
 	b[3] = byte(i >> 8)

--- a/packstream/packstream_test.go
+++ b/packstream/packstream_test.go
@@ -37,14 +37,14 @@ func (s *PackstreamSuite) TestDecodeBool(c *C) {
 		c.Fatal(err)
 	}
 
-	n, err := buf.Write([]byte{TRUE})
+	n, err := buf.Write([]byte{True})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 1)
 	v, err := decoder.Decode()
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, true)
 
-	n, err = buf.Write([]byte{FALSE})
+	n, err = buf.Write([]byte{False})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 1)
 	v, err = decoder.Decode()


### PR DESCRIPTION
When opening this project the linter cries foul about all the const names.
It would probably make sense to stick to the Go convention (https://golang.org/doc/effective_go.html#mixed-caps).